### PR TITLE
Fix error in compute_parent_groups function when all group memberships are deleted

### DIFF
--- a/g2p_registry_membership/models/group_membership.py
+++ b/g2p_registry_membership/models/group_membership.py
@@ -117,9 +117,11 @@ class G2PGroupMembership(models.Model):
         return self._search(args, limit=limit, access_rights_uid=name_get_uid)
 
     def _recompute_parent_groups(self, records):
-        field = self.env["res.partner"]._fields["force_recompute_canary"]
-        groups = records.mapped("group")
-        self.env.add_to_compute(field, groups)
+        # Check if group field is in records
+        if "group" in records._fields:
+            field = self.env["res.partner"]._fields["force_recompute_canary"]
+            groups = records.mapped("group")
+            self.env.add_to_compute(field, groups)
 
     def write(self, vals):
         res = super(G2PGroupMembership, self).write(vals)


### PR DESCRIPTION
Fix error when all group memberships are deleted and the write function calls the _compute_parent_groups function. The error points to `groups = records.mapped("group")` with the detail: Key error "group".