### PR TITLE
remove display_notification js

### DIFF
--- a/g2p_registry_base/__manifest__.py
+++ b/g2p_registry_base/__manifest__.py
@@ -23,9 +23,6 @@
         "views/tags_view.xml",
     ],
     "assets": {
-        "web.assets_backend": [
-            "/g2p_registry_base/static/src/js/custom_client_action.js",
-        ],
         "web.assets_qweb": [
             "g2p_registry_base/static/src/xml/custom_web.xml",
         ],


### PR DESCRIPTION
Details/Explanation: Since we are no longer using the 'Refresh' custom function in display notification, remove this function to eliminate the warning it produces in the browser's console log.