### PR TITLE
G2P-2372 alignment issue

### DIFF
--- a/g2p_registry_individual/views/individuals_view.xml
+++ b/g2p_registry_individual/views/individuals_view.xml
@@ -171,10 +171,8 @@
                                 </group>
                             </group>
                             <group col="6" colspan="6">
-                                <group colspan="6">
-                                    <field name="birth_place" readonly="disabled" />
-                                </group>
                                 <group colspan="3">
+                                    <field name="birth_place" readonly="disabled" />
                                     <field
                                         name="birthdate"
                                         readonly="disabled"


### PR DESCRIPTION
Registry_Individual_Personal Info_Birthplace text is now aligned properly with other fields