### PR TITLE
Fix company not able to create

### DIFF
--- a/g2p_registry_base/models/registrant.py
+++ b/g2p_registry_base/models/registrant.py
@@ -118,8 +118,8 @@ class G2PRegistrant(models.Model):
 
         This is to fix the issue that is occuring when the user is trying to create a new company in an
         instance that has "stock" module and "g2p_registry_base" module installed. The issue is that the
-        `_check_company` function checks if the company of the record is either False or the same with the record's
-        company.
+        `_check_company` function checks if the company of the record is either
+        False or the same with the record's company.
 
         To replicate the issue:
         1. Install the "stock" module and "g2p_registry_base" module.

--- a/g2p_registry_base/models/registrant.py
+++ b/g2p_registry_base/models/registrant.py
@@ -124,7 +124,7 @@ class G2PRegistrant(models.Model):
         To replicate the issue:
         1. Install the "stock" module and "g2p_registry_base" module.
         2. Create a new company.
-        3. "Incompatible companies on records" error will occur.
+        3. "Incompatible companies on records" error should not occur.
         """
 
         domain = super()._check_company_domain(companies)


### PR DESCRIPTION
## Why is this change needed?

`Incompatible companies on records` error is showing when creating a company. This error only shows if `stock` module and `g2p_registry_base` module is installed. This happens because normally, company_id of res.partner is not required and do not have a default value that's why the `_check_company` function of BaseModel checks only if the record's company is either False or compatible, but because of the default value, it is now neither False or compatible. 

## How was the change implemented?

To solve above error, the default company that is set in the company_id field is now added in the domain of the function `_check_company_domain`

## How to test manually...
1. Install the "stock" module and "g2p_registry_base" module.
2. Create a new company.
3. "Incompatible companies on records" error should not occur.