### PR TITLE
fixed age field readonly

### DIFF
--- a/g2p_registry_individual/views/individuals_view.xml
+++ b/g2p_registry_individual/views/individuals_view.xml
@@ -180,7 +180,7 @@
                                         placeholder="mm/dd/yyyy"
                                     />
                                     <field name="birthdate_not_exact" readonly="disabled" />
-                                    <field name="age" readonly="disabled" />
+                                    <field name="age" />
                                     <field name="gender" readonly="disabled" />
                                 </group>
                                 <group colspan="3">


### PR DESCRIPTION
## Why is this change needed?

Currently, Age field becomes editable if the individual is not disable. Age field should always be readonly without any conditions.

## How was the change implemented?

Remove the attribute readonly in the xml since age field in model already have a parameter readonly that is set to True

## How to test manually...
1. Navigate to Registry -> Individual -> enter one record.
2. Age field should not be editable even if the individual is either Active or Disabled.