### PR TITLE
Fix name change function

### DIFF
--- a/g2p_registry_individual/models/individual.py
+++ b/g2p_registry_individual/models/individual.py
@@ -30,13 +30,17 @@ class G2PIndividual(models.Model):
     def name_change(self):
         vals = {}
         if not self.is_group:
-            name = ""
-            if self.family_name:
-                name += self.family_name + ", "
-            if self.given_name:
-                name += self.given_name + " "
-            if self.addl_name:
-                name += self.addl_name + " "
+            name_vals = [
+                f"{self.family_name},"
+                if self.family_name and self.given_name
+                else f"{self.family_name}"
+                if self.family_name
+                else "",
+                self.given_name,
+                self.addl_name,
+            ]
+
+            name = " ".join(filter(None, name_vals))
             vals.update({"name": name.upper()})
             self.update(vals)
 

--- a/g2p_registry_individual/models/individual.py
+++ b/g2p_registry_individual/models/individual.py
@@ -32,7 +32,7 @@ class G2PIndividual(models.Model):
         if not self.is_group:
             name_vals = [
                 f"{self.family_name},"
-                if self.family_name and self.given_name
+                if self.family_name and (self.given_name or self.addl_name)
                 else f"{self.family_name}"
                 if self.family_name
                 else "",

--- a/g2p_registry_individual/tests/test_individuals.py
+++ b/g2p_registry_individual/tests/test_individuals.py
@@ -53,32 +53,56 @@ class IndividualsTest(TransactionCase):
                 "is_registrant": True,
             }
         )
+        cls.registrant_no_given_name = cls.env["res.partner"].create(
+            {
+                "name": "Josephine Demophon",
+                "family_name": "Demophon",
+                "given_name": "",
+                "addl_name": "Josephine",
+                "is_group": False,
+                "is_registrant": True,
+            }
+        )
+        cls.registrant_no_addl_name = cls.env["res.partner"].create(
+            {
+                "name": "Amaphia Demophon",
+                "family_name": "Demophon",
+                "given_name": "Amaphia",
+                "addl_name": "",
+                "is_group": False,
+                "is_registrant": True,
+            }
+        )
+        cls.registrant_all_names = cls.env["res.partner"].create(
+            {
+                "name": "Amaphia Jospehine Demophon",
+                "family_name": "Demophon",
+                "given_name": "Amaphia",
+                "addl_name": "Josephine",
+                "is_group": False,
+                "is_registrant": True,
+            }
+        )
+        cls.registrant_no_family_name = cls.env["res.partner"].create(
+            {
+                "name": "Amaphia Jospehine",
+                "family_name": "",
+                "given_name": "Amaphia",
+                "addl_name": "Josephine",
+                "is_group": False,
+                "is_registrant": True,
+            }
+        )
 
-    def test_01_check_names(self):
-        self.registrant_1.name_change()
-        message = "NAME FAILED (EXPECTED {} but RESULT is {})".format(
-            "JADDRANKA, HEIDI ",
-            self.registrant_1.name,
-        )
-        self.assertEqual(self.registrant_1.name, "JADDRANKA, HEIDI ", message)
-        self.registrant_2.name_change()
-        message = "NAME FAILED (EXPECTED {} but RESULT is {})".format(
-            "KLEITOS, ANGUS ",
-            self.registrant_2.name,
-        )
-        self.assertEqual(self.registrant_2.name, "KLEITOS, ANGUS ", message)
-        self.registrant_3.name_change()
-        message = "NAME FAILED (EXPECTED {} but RESULT is {})".format(
-            "CARATACOS, SORA ",
-            self.registrant_3.name,
-        )
-        self.assertEqual(self.registrant_3.name, "CARATACOS, SORA ", message)
-        self.registrant_4.name_change()
-        message = "NAME FAILED (EXPECTED {} but RESULT is {})".format(
-            "DEMOPHON, AMAPHIA ",
-            self.registrant_4.name,
-        )
-        self.assertEqual(self.registrant_4.name, "DEMOPHON, AMAPHIA ", message)
+    def test_01_check_name_change(self):
+        self.registrant_no_family_name.name_change()
+        self.assertEqual(self.registrant_no_family_name.name, "AMAPHIA JOSEPHINE")
+        self.registrant_all_names.name_change()
+        self.assertEqual(self.registrant_all_names.name, "DEMOPHON, AMAPHIA JOSEPHINE")
+        self.registrant_no_addl_name.name_change()
+        self.assertEqual(self.registrant_no_addl_name.name, "DEMOPHON, AMAPHIA")
+        self.registrant_no_given_name.name_change()
+        self.assertEqual(self.registrant_no_given_name.name, "DEMOPHON, JOSEPHINE")
 
     def test_02_age_calculation(self):
         start_date = date(2000, 1, 1)


### PR DESCRIPTION
The name change function added a whitespace at the end of the string, which caused problems that were not easily spotted by a user.

This fix changes the following:
- Adjusting the `name_change` function to be more Pythonic, and faster, and make sure there is no trailing space.
- Adjusting the test for the `name_change` function to cover the possible scenarios of the function.