### PR TITLE
revert(widget): restore Widgetpreview for consistency

### DIFF
--- a/g2p_documents/static/src/js/preview_document.js
+++ b/g2p_documents/static/src/js/preview_document.js
@@ -6,13 +6,13 @@ import {registry} from "@web/core/registry";
 import {useFileViewer} from "@web/core/file_viewer/file_viewer_hook";
 import {useService} from "@web/core/utils/hooks";
 
-class G2PDocumentPreview extends Component {
+class Widgetpreview extends Component {
     setup() {
         this.dialog = useService("dialog");
         this.fileViewer = useFileViewer();
     }
 
-    async clickPreview() {
+    clickPreview() {
         const record = this.props.record?.data || {};
         const {id, name, url, mimetype = ""} = record;
 
@@ -30,11 +30,11 @@ class G2PDocumentPreview extends Component {
                 isPdf,
             });
         } else if (url) {
-            await this.downloadUnPreviewedFile(url, name);
+            this.downloadUnPreviewedFile(url, name);
         }
     }
 
-    async downloadUnPreviewedFile(url, filename) {
+    downloadUnPreviewedFile(url, filename) {
         const fileName = filename || "file";
 
         this.dialog.add(ConfirmationDialog, {
@@ -55,31 +55,9 @@ class G2PDocumentPreview extends Component {
             },
         });
     }
-
-    getFileIcon() {
-        const filename = this.props.record?.data?.name || "";
-        const ext = filename.split(".").pop()?.toLowerCase();
-        const icons = {
-            pdf: "pdf",
-            jpg: "image",
-            jpeg: "image",
-            png: "image",
-            gif: "image",
-            webp: "image",
-            txt: "text",
-            csv: "text",
-            doc: "word",
-            docx: "word",
-            xls: "excel",
-            xlsx: "excel",
-            ppt: "powerpoint",
-            pptx: "powerpoint",
-        };
-        return `fa-file-${icons[ext] || "o"}-o`;
-    }
 }
 
-G2PDocumentPreview.template = "g2p_documents.Widgetpreview";
+Widgetpreview.template = "g2p_documents.Widgetpreview";
 registry.category("view_widgets").add("g2p_documents_action_preview", {
-    component: G2PDocumentPreview,
+    component: Widgetpreview,
 });

--- a/g2p_documents/static/src/js/preview_document.js
+++ b/g2p_documents/static/src/js/preview_document.js
@@ -6,7 +6,7 @@ import {registry} from "@web/core/registry";
 import {useFileViewer} from "@web/core/file_viewer/file_viewer_hook";
 import {useService} from "@web/core/utils/hooks";
 
-class Widgetpreview extends Component {
+export class Widgetpreview extends Component {
     setup() {
         this.dialog = useService("dialog");
         this.fileViewer = useFileViewer();

--- a/g2p_documents/static/src/xml/preview_document.xml
+++ b/g2p_documents/static/src/xml/preview_document.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
     <t t-name="g2p_documents.Widgetpreview">
-        <button t-on-click="clickPreview" class="btn btn-primary" title="Preview File">
-                <i t-attf-class="fa {{getFileIcon()}}" /> Preview
-        </button>
+        <button t-on-click="clickPreview" class="btn btn-primary">Preview</button>
     </t>
 </templates>


### PR DESCRIPTION
**This PR reverts the rename of Widgetpreview to G2pDocumentPreview.**
Restoring Widgetpreview ensures consistency, as it's used in multiple places across the codebase.