### PR TITLE
G2P-3663: Remove filter condition for valid status so we can generate UID for all IDs 

### DIFF
--- a/g2p_registry_rest_api/routers/individual.py
+++ b/g2p_registry_rest_api/routers/individual.py
@@ -131,7 +131,6 @@ async def get_individual_ids(
         include_reg_ids = reg_id_model.search(
             [
                 ("id_type", "=", include_type_rec.id),
-                ("status", "=", "valid"),
                 ("partner_id.is_registrant", "=", True),
                 ("partner_id.is_group", "=", False),
                 ("partner_id.active", "=", True),


### PR DESCRIPTION
Remove filter condition for valid status while fetching registration ids so we can generate UID for all IDs regardless of status